### PR TITLE
[WIP] move pdf creation to child process

### DIFF
--- a/assets/startup/build.sh
+++ b/assets/startup/build.sh
@@ -2,6 +2,6 @@
 
 echo 'Generating PDFs'
 echo 'Installing node dependencies'
-npm i html-pdf glob jsdom js-yaml
-node _site/assets/startup/pdf-gen.js
+npm i html-pdf glob jsdom js-yaml semaphore
+node _site/assets/startup/pdfgen-parent.js
 echo 'Generating PDFs Complete'

--- a/assets/startup/pdfgen-child.js
+++ b/assets/startup/pdfgen-child.js
@@ -1,0 +1,104 @@
+const fs = require('fs')
+const pdf = require('html-pdf')
+const path = require('path')
+const jsdom = require('jsdom')
+const sitePath = __dirname + '/../..'
+const options = {
+    height: '594mm',        // allowed units: mm, cm, in, px
+    width: '420mm',
+    base: 'file://' + sitePath + '/',
+    border: {
+        right: '100px', // default is 0, units: mm, cm, in, px
+        left: '100px',
+    },
+    header: {
+        height: '80px',
+    },
+    footer: {
+        height: '80px',
+    },
+}
+
+// Concatenates the contents in .html files, and outputs export.pdf in the specified output folder
+const createPdf = (htmlFilePaths, outputFolderPath) => {
+    // docprint.html is our template to build pdf up from.
+    const exportHtmlFile = fs.readFileSync(__dirname + '/docprint.html')
+    const exportDom = new jsdom.JSDOM(exportHtmlFile)
+    const exportDomBody = exportDom.window.document.body
+    const exportDomMain = exportDom.window.document.getElementById('main-content')
+    let addedTitle = false
+    let addedDocTitle = false
+
+    htmlFilePaths.forEach(function (filePath) {
+        const file = fs.readFileSync(filePath)
+        const dom = new jsdom.JSDOM(file)
+
+        // html-pdf can't deal with these
+        removeTagsFromDom(dom, 'script')
+        removeTagsFromDom(dom, 'iframe')
+
+        // If a <img src=...> link src begins with '/', it is a relative link
+        // and needs to be prepended with '.' to make the images show in the pdf
+        const imgsrcs = dom.window.document.getElementsByTagName('img')
+        for (let i = 0; i < imgsrcs.length; i++) {
+            const imgsrc = imgsrcs[i]
+            if (imgsrc.src.startsWith('/')) {
+                imgsrc.src = '.' + imgsrc.src
+            } else if (imgsrc.src.startsWith('.')) {
+                imgsrc.src = outputFolderPath + imgsrc.src.substr(1)
+            }
+        }
+
+        // Site titles needs only be added once
+        if (!addedTitle) {
+            try {
+                const oldTitle = dom.window.document.getElementsByClassName('site-header-text')[0]
+                exportDomBody.insertBefore(oldTitle, exportDomMain)
+                addedTitle = true
+            } catch (error) {
+                console.log('Failed to append Title, skipping: ' + error)
+            }
+        }
+        // Document titles too
+        if (!addedDocTitle) {
+            try {
+                const oldDocTitle = dom.window.document.getElementsByClassName('description-container')[0]
+                exportDomBody.insertBefore(oldDocTitle, exportDomMain)
+                const hr = dom.window.document.createElement('HR')
+                exportDomBody.insertBefore(hr, exportDomMain)
+                addedDocTitle = true
+            } catch (error) {
+                console.log('Failed to append Doc Title, skipping: ' + error)
+            }
+        }
+
+        // Concat all the id:main-content divs
+        try {
+            const oldNode = dom.window.document.getElementById('main-content')
+            exportDomMain.innerHTML += oldNode.innerHTML
+        } catch (error) {
+            console.log('Failed to append Node, skipping: ' + error)
+        }
+    })
+
+    return new Promise((resolve, reject) => {
+        pdf.create(exportDom.serialize(), options).toFile(path.join(outputFolderPath, 'export.pdf'), (err, res) => {
+            if (err) return reject(err)
+            console.log('Pdf created at: ', res.filename)
+            resolve()
+        })
+    }).then((res) => {
+        process.exit()
+    })
+}
+
+// Removes <tag></tag> from dom and everything in between them
+const removeTagsFromDom = (dom, tagname) => {
+    const tags = dom.window.document.getElementsByTagName(tagname)
+    for (let i = tags.length - 1; i >= 0; i--) {
+        tags[i].parentNode.removeChild(tags[i])
+    }
+}
+
+const args = [JSON.parse(process.argv[2]), process.argv[3]]
+createPdf(args[0], args[1])

--- a/assets/startup/pdfgen-parent.js
+++ b/assets/startup/pdfgen-parent.js
@@ -1,32 +1,18 @@
 const fs = require('fs')
-const pdf = require('html-pdf')
 const glob = require('glob')
 const path = require('path')
-const jsdom = require('jsdom')
+
+const MAX_CHILDREN = 5
+const sem = require('semaphore')(MAX_CHILDREN)
 const jsyaml = require('js-yaml')
 const sitePath = __dirname + '/../..'
-const options = {
-    height: '594mm',        // allowed units: mm, cm, in, px
-    width: '420mm',
-    base: 'file://' + sitePath + '/',
-    border: {
-        right: '100px', // default is 0, units: mm, cm, in, px
-        left: '100px',
-    },
-    header: {
-        height: '80px',
-    },
-    footer: {
-        height: '80px',
-    },
-}
+
 // List of top-level folder names which may contain html but are not to be printed
 const printIgnoreFolders = ['assets', 'files', 'iframes', 'images']
 // List of top-level .html files which are not to be printed
 const printIgnoreFiles = ['export.html', 'index.html']
 
 const main = async () => {
-    console.log('Base options: ', options.base)
     // creating exports of individual documents
     const docFolders = getDocumentFolders(sitePath, printIgnoreFolders)
     await exportPdfDocFolders(sitePath, docFolders)
@@ -45,7 +31,9 @@ const exportPdfTopLevelDocs = async (sitePath) => {
         const order = mapSectionNameToHtmlFilename(configYml, sitePath)
         htmlFilePaths = reorderHtmlFilePaths(htmlFilePaths, order)
     }
-    await createPdf(htmlFilePaths, sitePath)
+    const args = [JSON.stringify(htmlFilePaths), sitePath]
+    const child = require('child_process')
+                    .fork(path.join(sitePath, 'assets', 'startup', 'pdfgen-child.js'), args)
 }
 
 const exportPdfDocFolders = async (sitePath, docFolders) => {
@@ -64,79 +52,24 @@ const exportPdfDocFolders = async (sitePath, docFolders) => {
             const order = configMd.meta.order // names of html files without the .html
             htmlFilePaths = reorderHtmlFilePaths(htmlFilePaths, order)
         }
-        await createPdf(htmlFilePaths, folderPath)
-    }
-}
 
-// Concatenates the contents in .html files, and outputs export.pdf in the specified output folder
-const createPdf = (htmlFilePaths, outputFolderPath) => {
-    // docprint.html is our template to build pdf up from.
-    const exportHtmlFile = fs.readFileSync(__dirname + '/docprint.html')
-    const exportDom = new jsdom.JSDOM(exportHtmlFile)
-    const exportDomBody = exportDom.window.document.body
-    const exportDomMain = exportDom.window.document.getElementById('main-content')
-    let addedTitle = false
-    let addedDocTitle = false
-
-    htmlFilePaths.forEach(function (filePath) {
-        const file = fs.readFileSync(filePath)
-        const dom = new jsdom.JSDOM(file)
-
-        // html-pdf can't deal with these
-        removeTagsFromDom(dom, 'script')
-        removeTagsFromDom(dom, 'iframe')
-
-        // If a <img src=...> link src begins with '/', it is a relative link
-        // and needs to be prepended with '.' to make the images show in the pdf
-        const imgsrcs = dom.window.document.getElementsByTagName('img')
-        for (let i = 0; i < imgsrcs.length; i++) {
-            const imgsrc = imgsrcs[i]
-            if (imgsrc.src.startsWith('/')) {
-                imgsrc.src = '.' + imgsrc.src
-            } else if (imgsrc.src.startsWith('.')) {
-                imgsrc.src = outputFolderPath + imgsrc.src.substr(1)
-            }
-        }
-
-        // Site titles needs only be added once
-        if (!addedTitle) {
-            try {
-                const oldTitle = dom.window.document.getElementsByClassName('site-header-text')[0]
-                exportDomBody.insertBefore(oldTitle, exportDomMain)
-                addedTitle = true
-            } catch (error) {
-                console.log('Failed to append Title, skipping: ' + error)
-            }
-        }
-        // Document titles too
-        if (!addedDocTitle) {
-            try {
-                const oldDocTitle = dom.window.document.getElementsByClassName('description-container')[0]
-                exportDomBody.insertBefore(oldDocTitle, exportDomMain)
-                const hr = dom.window.document.createElement('HR')
-                exportDomBody.insertBefore(hr, exportDomMain)
-                addedDocTitle = true
-            } catch (error) {
-                console.log('Failed to append Doc Title, skipping: ' + error)
-            }
-        }
-
-        // Concat all the id:main-content divs
-        try {
-            const oldNode = dom.window.document.getElementById('main-content')
-            exportDomMain.innerHTML += oldNode.innerHTML
-        } catch (error) {
-            console.log('Failed to append Node, skipping: ' + error)
-        }
-    })
-
-    return new Promise((resolve, reject) => {
-        pdf.create(exportDom.serialize(), options).toFile(path.join(outputFolderPath, 'export.pdf'), (err, res) => {
-            if (err) return reject(err)
-            console.log('Pdf created at: ', res.filename)
-            resolve()
+        /**
+         * Because the PDF creation is a rather heavy step and for some reason firing off
+         * multiple promises within the same NodeJS process does not make it any faster,
+         * We will spawn each PDF creation in a separate real process and make sure
+         * that it exits at the end. The spwaning is controlled using semaphores to ensure
+         * that an excessive number of NodeJS processes are not created at the same time.
+         */
+        const args = [JSON.stringify(htmlFilePaths), folderPath]
+        sem.take(() => {
+            const child = require('child_process')
+                            .fork(path.join(sitePath, 'assets', 'startup', 'pdfgen-child.js'), args)
+            child.on('exit', (code) => {
+                sem.leave()
+            })
         })
-    }) 
+
+    }
 }
 
 // Returns a list of the valid document (i.e. folder) paths
@@ -178,14 +111,6 @@ const reorderHtmlFilePaths = (htmlFilePaths, order) => {
         }
     }
     return htmlFilePaths
-}
-
-// Removes <tag></tag> from dom and everything in between them
-const removeTagsFromDom = (dom, tagname) => {
-    const tags = dom.window.document.getElementsByTagName(tagname)
-    for (let i = tags.length - 1; i >= 0; i--) {
-        tags[i].parentNode.removeChild(tags[i])
-    }
 }
 
 // Section names correspond to titles at the top of .md files in source folder


### PR DESCRIPTION
 - Having PDF.create synchronously is too slow
 - Instantiating multiple PDF.creates in the same NodeJS process took up too much memory at once and also was not any faster than synchronously
 - Instantiating multiple PDF.creates in a limited number of real, child processes seems to be faster as well as providing the ability to limit memory usage