### PR TITLE
S3pdf

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ kramdown:
 repository: opendocsg/opendoc-theme
 server_PROD: https://search.opendoc.sg
 server_DEV: https://search-staging.opendoc.sg
+PDF_storage_URL: https://opendoc-theme-pdf.s3-ap-southeast-1.amazonaws.com/opendoc-theme
 fast_build: true
 offline_search_only: false
 

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ server_PROD: https://search.opendoc.sg
 server_DEV: https://search-staging.opendoc.sg
 
 fast_build: true
-offline_search_only: false
+offline: false
 
 
 subtitle: this is a subtitle

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ kramdown:
 repository: opendocsg/opendoc-theme
 server_PROD: https://search.opendoc.sg
 server_DEV: https://search-staging.opendoc.sg
-PDF_storage_URL: https://opendoc-theme-pdf.s3-ap-southeast-1.amazonaws.com/opendoc-theme
+
 fast_build: true
 offline_search_only: false
 

--- a/_layouts/print.html
+++ b/_layouts/print.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="./assets/styles/main.css">
   </head>
 
-  <body id="print-content">
+  <body class="print-content">
     <section class="description">
       <img class="description-logo" src="{{ '.' | append: site.styling_options.logo_path }}">
       <div class="description-title">{{ site.title }}</div>

--- a/_sass/_print.scss
+++ b/_sass/_print.scss
@@ -1,5 +1,4 @@
-#print-content {
-  /* print styles go here */
+.print-content {
   .site-header-text {
     color: $primary-brand-color;
     font-family: $header-font-family;
@@ -18,6 +17,34 @@
     padding-top: 0;
     margin-top: -40px;
     position: relative;
+    font-size: $base-font-size;
+  }
+}
+
+.print-content-small {
+  .site-header-text {
+    font-size: 25px;
+  }
+
+  #document-title {
+    font-size: 20px;
+  }
+
+  #main-content {
+    font-size: 13px;
+  }
+}
+
+.print-content-large {
+  .site-header-text {
+    font-size: 40px;
+  }
+
+  #document-title {
+    font-size: 30px;
+  }
+
+  #main-content {
     font-size: $base-font-size;
   }
 }

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -92,7 +92,7 @@
 
     // Load Lunr Index if set
     // ============================================================================
-    var searchSetOffline = "{{ site.offline_search_only }}" === "true" || false
+    var searchSetOffline = "{{ site.offline }}" === "true" || false
 
     if (searchSetOffline) {
         getLunrIndex()

--- a/assets/js/toolbar.js
+++ b/assets/js/toolbar.js
@@ -63,7 +63,7 @@
         btn.addEventListener('click', function () {
             var repoUrl = '{{ site.PDF_storage_URL }}'
             var page = pageIndex[window.location.pathname]
-            var documentTitle = page.dir !== '/' ? page.dir : '/root/'
+            var documentTitle = page.dir !== '/' ? page.dir : '/export/'
             if (documentTitle) {
                 repoUrl += documentTitle.substring(0, documentTitle.length-1) + '.pdf'
             }

--- a/assets/js/toolbar.js
+++ b/assets/js/toolbar.js
@@ -61,7 +61,13 @@
 
     printButtons.forEach(function (btn) {
         btn.addEventListener('click', function () {
-            window.open('./export.pdf', '_blank')
+            var repoUrl = '{{ site.PDF_storage_URL }}'
+            var page = pageIndex[window.location.pathname]
+            var documentTitle = page.dir !== '/' ? page.dir : '/root/'
+            if (documentTitle) {
+                repoUrl += documentTitle.substring(0, documentTitle.length-1) + '.pdf'
+            }
+            window.open(repoUrl, '_blank')
         })
     })
 

--- a/assets/js/toolbar.js
+++ b/assets/js/toolbar.js
@@ -61,13 +61,16 @@
 
     printButtons.forEach(function (btn) {
         btn.addEventListener('click', function () {
-            var repoUrl = '{{ site.PDF_storage_URL }}'
+            var S3Url = 'https://opendoc-theme-pdf.s3-ap-southeast-1.amazonaws.com'
             var page = pageIndex[window.location.pathname]
+            // documentTitle refers to the name of the document folder
+            // If page.dir is slash, that indicates the root directory
+            // PDF at root dir is named export.pdf
             var documentTitle = page.dir !== '/' ? page.dir : '/export/'
             if (documentTitle) {
-                repoUrl += documentTitle.substring(0, documentTitle.length-1) + '.pdf'
+                S3Url += documentTitle.substring(0, documentTitle.length-1) + '.pdf'
             }
-            window.open(repoUrl, '_blank')
+            window.open(S3Url, '_blank')
         })
     })
 

--- a/assets/js/toolbar.js
+++ b/assets/js/toolbar.js
@@ -61,9 +61,10 @@
 
     printButtons.forEach(function (btn) {
         btn.addEventListener('click', function () {
+            var replacedRepoName = '{{ site.repository }}'.replace(/\//g, '-')
             var pdfUrl = '{{ site.offline }}' === 'true' ?
-                '{{ "/assets/pdfs/" | relative_url }}' :
-                'https://opendoc-theme-pdf.s3-ap-southeast-1.amazonaws.com'
+                '{{ "/assets/pdfs" | relative_url }}' :
+                'https://opendoc-theme-pdf.s3-ap-southeast-1.amazonaws.com/' + replacedRepoName
             var page = pageIndex[window.location.pathname]
             // documentTitle refers to the name of the document folder
             // If page.dir is slash, that indicates the root directory

--- a/assets/js/toolbar.js
+++ b/assets/js/toolbar.js
@@ -61,7 +61,8 @@
 
     printButtons.forEach(function (btn) {
         btn.addEventListener('click', function () {
-            var replacedRepoName = '{{ site.repository }}'.replace(/\//g, '-')
+            // S3 folder; replace slashes to avoid creating sub-folders
+            var replacedRepoName = '{{ site.title | default: "default" }}'.replace(/\//g, '-').replace(/\s+/g, '-')
             var pdfUrl = '{{ site.offline }}' === 'true' ?
                 '{{ "/assets/pdfs" | relative_url }}' :
                 'https://opendoc-theme-pdf.s3-ap-southeast-1.amazonaws.com/' + replacedRepoName

--- a/assets/js/toolbar.js
+++ b/assets/js/toolbar.js
@@ -61,8 +61,8 @@
 
     printButtons.forEach(function (btn) {
         btn.addEventListener('click', function () {
-            // S3 folder name; replace slashes and spaces to avoid creating sub-folders
-            var replacedRepoName = '{{ site.title | default: "default" }}'.replace(/\//g, '-').replace(/\s+/g, '-')
+            // S3 folder name; replace slashes to avoid creating sub-folders
+            var replacedRepoName = '{{ site.repository }}'.replace(/\//g, '-')
             var pdfUrl = '{{ site.offline }}' === 'true' ?
                 '{{ "/assets/pdfs" | relative_url }}' :
                 'https://opendoc-theme-pdf.s3-ap-southeast-1.amazonaws.com/' + replacedRepoName

--- a/assets/js/toolbar.js
+++ b/assets/js/toolbar.js
@@ -61,16 +61,18 @@
 
     printButtons.forEach(function (btn) {
         btn.addEventListener('click', function () {
-            var S3Url = 'https://opendoc-theme-pdf.s3-ap-southeast-1.amazonaws.com'
+            var pdfUrl = '{{ site.offline }}' === 'true' ?
+                '{{ "/assets/pdfs/" | relative_url }}' :
+                'https://opendoc-theme-pdf.s3-ap-southeast-1.amazonaws.com'
             var page = pageIndex[window.location.pathname]
             // documentTitle refers to the name of the document folder
             // If page.dir is slash, that indicates the root directory
             // PDF at root dir is named export.pdf
             var documentTitle = page.dir !== '/' ? page.dir : '/export/'
             if (documentTitle) {
-                S3Url += documentTitle.substring(0, documentTitle.length-1) + '.pdf'
+                pdfUrl += documentTitle.substring(0, documentTitle.length-1) + '.pdf'
             }
-            window.open(S3Url, '_blank')
+            window.open(pdfUrl, '_blank')
         })
     })
 

--- a/assets/js/toolbar.js
+++ b/assets/js/toolbar.js
@@ -61,7 +61,7 @@
 
     printButtons.forEach(function (btn) {
         btn.addEventListener('click', function () {
-            // S3 folder; replace slashes to avoid creating sub-folders
+            // S3 folder name; replace slashes and spaces to avoid creating sub-folders
             var replacedRepoName = '{{ site.title | default: "default" }}'.replace(/\//g, '-').replace(/\s+/g, '-')
             var pdfUrl = '{{ site.offline }}' === 'true' ?
                 '{{ "/assets/pdfs" | relative_url }}' :

--- a/assets/startup/build.sh
+++ b/assets/startup/build.sh
@@ -5,14 +5,12 @@
 echo 'Started script to generate PDFs'
 echo 'Installing node dependencies'
 npm i glob jsdom js-yaml p-all
-if [[ (-z "${PDF_GEN_API_SERVER}") || (-z "${PDF_GEN_API_KEY}") ]]; then
-  npm i html-pdf
-fi
-node _site/assets/startup/pdf-gen.js
 if [ "{{ site.offline }}" == "true" ]; then
     node _site/assets/startup/prebuild-lunr-index.js
-    echo 'Generating Lunr Index complete'
+    echo 'Generating lunr index complete'
+    npm i html-pdf
 else
-    echo 'Skipping Lunr Index'
+    echo 'Skipping lunr index'
 fi
+node _site/assets/startup/pdf-gen.js
 echo 'End script'

--- a/assets/startup/build.sh
+++ b/assets/startup/build.sh
@@ -9,7 +9,7 @@ if [[ (-z "${PDF_GEN_API_SERVER}") || (-z "${PDF_GEN_API_KEY}") ]]; then
   npm i html-pdf
 fi
 node _site/assets/startup/pdf-gen.js
-if [ "{{ site.offline_search_only }}" == "true" ]; then
+if [ "{{ site.offline }}" == "true" ]; then
     node _site/assets/startup/prebuild-lunr-index.js
     echo 'Generating Lunr Index complete'
 else

--- a/assets/startup/docprint.html
+++ b/assets/startup/docprint.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="./assets/styles/main.css">
 </head>
 
-<body id=print-content>
+<body class=print-content>
   <div id="main-content" class="site-main">
   </div>
 </body>

--- a/assets/startup/pdf-gen.js
+++ b/assets/startup/pdf-gen.js
@@ -14,7 +14,7 @@ let generatingPdfLocally = '{{ site.offline }}' === 'true' || false
 const S3StorageUrl = new URL('https://opendoc-theme-pdf.s3-ap-southeast-1.amazonaws.com')
 
 const localPdfFolder = path.join(sitePath, 'assets', 'pdfs') // local folder for pdfs
-const S3PdfFolder = '{{ site.repository }}'.replace(/\//g, '-') // S3 folder; replace slashes to avoid creating sub-folders
+const S3PdfFolder = '{{ site.github.repository }}'.replace(/\//g, '-') // S3 folder; replace slashes to avoid creating sub-folders
 
 const bucketName = S3StorageUrl.hostname.split('.')[0]
 

--- a/assets/startup/pdf-gen.js
+++ b/assets/startup/pdf-gen.js
@@ -115,7 +115,12 @@ const createPdf = (htmlFilePaths, outputFolderPath, documentName) => {
     logStartedPdf(outputFolderPath)
     // docprint.html is our template to build pdf up from.
     const exportHtmlFile = fs.readFileSync(__dirname + '/docprint.html')
-    const cssFile = fs.readFileSync(PATH_TO_CSS)
+    let cssFile = ''
+    try {
+        cssFile = fs.readFileSync(PATH_TO_CSS)
+    } catch(err) {
+        console.log('Failed to read CSS file at ' + PATH_TO_CSS +', CSS will not be applied')
+    }
     const exportDom = new jsdom.JSDOM(exportHtmlFile)
     const exportDomBody = exportDom.window.document.body
     const exportDomMain = exportDom.window.document.getElementById('main-content')
@@ -220,7 +225,7 @@ const createPdf = (htmlFilePaths, outputFolderPath, documentName) => {
                 resolve()
             })
             pdfExistsRequest.on('error', function (err) {
-                logErrorPdf('Request encountered error', err)
+                logErrorPdf(`pdfExistsRequest encountered error for ${pdfName}: `, err)
                 return reject()
             })
             pdfExistsRequest.end()
@@ -244,14 +249,14 @@ const createPdf = (htmlFilePaths, outputFolderPath, documentName) => {
                 return new Promise(function (resolve, reject) {
                     const pdfCreationRequest = https.request(process.env.PDF_GEN_API_SERVER, options, function (res) {
                         if (res.statusCode < 200 || res.statusCode >= 300) {
-                            logErrorPdf('Request status code', res.statusCode)
+                            logErrorPdf(`pdfCreationRequest status code for ${pdfName}: `, res.statusCode)
                             return reject()
                         }
                         logSuccessPdf(pdfName)
                         return resolve()
                     })
                     pdfCreationRequest.on('error', function(err) {
-                        logErrorPdf('Request encountered error:', err)
+                        logErrorPdf(`pdfCreationRequest encountered error for ${pdfName}:`, err)
                         return reject()
                     })
                     pdfCreationRequest.write(JSON.stringify(pdfCreationBody))

--- a/assets/startup/pdf-gen.js
+++ b/assets/startup/pdf-gen.js
@@ -14,8 +14,8 @@ let generatingPdfLocally = '{{ site.offline }}' === 'true' || false
 const S3StorageUrl = new URL('https://opendoc-theme-pdf.s3-ap-southeast-1.amazonaws.com')
 
 const localPdfFolder = path.join(sitePath, 'assets', 'pdfs') // local folder for pdfs
- // S3 folder; replace slashes and spaces to avoid creating sub-folders
-const S3PdfFolder = '{{ site.title | default: "default" }}'.replace(/\//g, '-').replace(/\s+/g, '-')
+ // S3 folder; replace slashes to avoid creating sub-folders
+const S3PdfFolder = '{{ site.repository }}'.replace(/\//g, '-')
 
 const bucketName = S3StorageUrl.hostname.split('.')[0]
 

--- a/assets/startup/pdf-gen.js
+++ b/assets/startup/pdf-gen.js
@@ -184,6 +184,7 @@ const createPdf = (htmlFilePaths, outputFolderPath, documentName) => {
     })
     const serializedHtmlHash = crypto.createHash('md5').update(exportDom.serialize()).digest('base64')
     exportDom.window.document.head.innerHTML += '<style>' + cssFile + '</style>'
+    console.log('createpdf hash for:' + outputFolderPath + ': ' + serializedHtmlHash)
     if (generatingPdfLocally) {
         exportDomBody.className += ' print-content-large'
         // Generate and store locally

--- a/assets/startup/pdf-gen.js
+++ b/assets/startup/pdf-gen.js
@@ -197,6 +197,7 @@ const createPdf = (htmlFilePaths, outputFolderPath, documentName) => {
     const serializedHtmlHash = crypto.createHash('md5').update(exportDom.serialize()).digest('base64')
     exportDom.window.document.head.innerHTML += '<style>' + cssFile + '</style>'
     if (generatingPdfLocally) {
+        exportDomBody.className += ' print-content-large'
         // Generate and store locally
         return new Promise((resolve, reject) => {
             const url = path.join(localPdfFolder, documentName + '.pdf')
@@ -211,6 +212,8 @@ const createPdf = (htmlFilePaths, outputFolderPath, documentName) => {
             exportDom.window.close()
         })
     } else {
+        // Apply small font sizes because puppeteer tends to print big
+        exportDomBody.className += ' print-content-small'
         // Code for this API lives at https://github.com/opendocsg/pdf-lambda
         const pdfName = `${documentName}.pdf`
         return new Promise(function (resolve, reject) {

--- a/assets/startup/pdf-gen.js
+++ b/assets/startup/pdf-gen.js
@@ -32,9 +32,9 @@ if (generatingPdfLocally) {
     pdf = require('html-pdf')
     console.log('Generating PDFs and storing locally instead.')
 } else {
-    if (process.env.PDF_GEN_API_KEY === undefined || 
-        process.env.PDF_GEN_API_SERVER === undefined) {
-            console.log('Environment variables PDF_GEN_API_KEY or PDF_GEN_API_SERVER for AWS Lambda not present')
+    if (process.env.PDF_LAMBDA_KEY === undefined || 
+        process.env.PDF_LAMBDA_SERVER === undefined) {
+            console.log('Environment variables PDF_LAMBDA_KEY or PDF_LAMBDA_SERVER for AWS Lambda not present')
             return
         }
     pdfGenConcurrency = process.env.PDF_GEN_CONCURRENCY !== undefined ?
@@ -235,7 +235,7 @@ const createPdf = (htmlFilePaths, outputFolderPath, documentName) => {
                 const options = {
                     method: 'POST',
                     headers: {
-                        'x-api-key': process.env.PDF_GEN_API_KEY,
+                        'x-api-key': process.env.PDF_LAMBDA_KEY,
                         'content-type': 'application/json',
                     }
                 }
@@ -247,7 +247,7 @@ const createPdf = (htmlFilePaths, outputFolderPath, documentName) => {
                     'bucketName': bucketName
                 }
                 return new Promise(function (resolve, reject) {
-                    const pdfCreationRequest = https.request(process.env.PDF_GEN_API_SERVER, options, function (res) {
+                    const pdfCreationRequest = https.request(process.env.PDF_LAMBDA_SERVER, options, function (res) {
                         if (res.statusCode < 200 || res.statusCode >= 300) {
                             logErrorPdf(`pdfCreationRequest status code for ${pdfName}: `, res.statusCode)
                             return reject()

--- a/assets/startup/pdf-gen.js
+++ b/assets/startup/pdf-gen.js
@@ -6,6 +6,7 @@ const pAll = require('p-all')
 const https = require('https')
 const glob = require('glob')
 const path = require('path')
+const URL = require('url').URL;
 const jsdom = require('jsdom')
 const jsyaml = require('js-yaml')
 const sitePath = __dirname + '/../..'

--- a/assets/startup/pdf-gen.js
+++ b/assets/startup/pdf-gen.js
@@ -109,7 +109,7 @@ const exportPdfDocFolders = (sitePath, docFolders) => {
         htmlFilePaths = htmlFilePaths.map((filepath) => path.join(folderPath, filepath))
 
         // Remove folders without HTML files (don't want empty pdfs)
-        if (htmlFilePaths.length === 0) return
+        if (htmlFilePaths.length === 0) continue
         numTotalPdfs++
         const indexFilepath = path.join(sitePath, '..', folder, 'index.md')
         if (indexFileHasValidOrdering(indexFilepath)) {

--- a/assets/startup/pdf-gen.js
+++ b/assets/startup/pdf-gen.js
@@ -66,9 +66,9 @@ const main = async () => {
     // creating exports of individual documents
     console.time(TIMER)
     const docFolders = getDocumentFolders(sitePath, printIgnoreFolders)
-    //await exportPdfTopLevelDocs(sitePath)
+    await exportPdfTopLevelDocs(sitePath)
     await exportPdfDocFolders(sitePath, docFolders)
-    console.log(`PDFs created with success:${numPdfsSuccess} error:${numPdfsError} total:${numTotalPdfs}`)
+    console.log(`PDFs created with success:${numPdfsSuccess} unchanged:${numPdfsUnchanged} error:${numPdfsError} total:${numTotalPdfs}`)
     console.timeEnd(TIMER)
 }
 
@@ -84,7 +84,7 @@ const exportPdfTopLevelDocs = async (sitePath) => {
         const configYml = yamlToJs(configFilepath)
         htmlFilePaths = reorderHtmlFilePaths(htmlFilePaths, configYml.order)
     }
-    await createPdf(htmlFilePaths, sitePath)
+    await createPdf(htmlFilePaths, sitePath, 'export')
 }
 
 const exportPdfDocFolders = (sitePath, docFolders) => {
@@ -211,7 +211,6 @@ const createPdf = (htmlFilePaths, outputFolderPath, documentName) => {
                 method: 'HEAD'
             }
             const pdfExistsRequest = https.request(pdfS3Url, options, function (res) {
-                console.log(res.statusCode)
                 if (res.statusCode === 404) {
                     return reject('PDF not present')
                 }
@@ -225,7 +224,7 @@ const createPdf = (htmlFilePaths, outputFolderPath, documentName) => {
                 resolve()
             })
             pdfExistsRequest.on('error', function (err) {
-                logErrorPdf(`pdfExistsRequest encountered error for ${pdfName}: `, err)
+                console.log(`pdfExistsRequest encountered error for ${pdfName}:, ${err}`)
                 return reject()
             })
             pdfExistsRequest.end()
@@ -262,7 +261,7 @@ const createPdf = (htmlFilePaths, outputFolderPath, documentName) => {
                     pdfCreationRequest.write(JSON.stringify(pdfCreationBody))
                     pdfCreationRequest.end()
                 }).catch((error) => {
-                    logErrorPdf('Request promise ', error)
+                    logErrorPdf(`pdfCreation promise error for ${pdfName}`, error)
                 }).finally(() => {
                     exportDom.window.close()
                 })

--- a/assets/startup/pdf-gen.js
+++ b/assets/startup/pdf-gen.js
@@ -35,7 +35,7 @@ if (generatingPdfLocally) {
     if (process.env.PDF_LAMBDA_KEY === undefined || 
         process.env.PDF_LAMBDA_SERVER === undefined) {
             console.log('Environment variables PDF_LAMBDA_KEY or PDF_LAMBDA_SERVER for AWS Lambda not present')
-            return
+            process.exit(1)
         }
     pdfGenConcurrency = process.env.PDF_GEN_CONCURRENCY !== undefined ?
         parseInt(process.env.PDF_GEN_CONCURRENCY) :

--- a/assets/startup/pdf-gen.js
+++ b/assets/startup/pdf-gen.js
@@ -198,7 +198,7 @@ const createPdf = (htmlFilePaths, outputFolderPath, documentName) => {
     if (generatingPdfLocally) {
         // Generate and store locally
         return new Promise((resolve, reject) => {
-            const url = path.join(localPdfFolder, encodeURIComponent(documentName) + '.pdf')
+            const url = path.join(localPdfFolder, documentName + '.pdf')
             pdf.create(exportDom.serialize(), localPdfOptions).toFile(url, (err, res) => {
                 if (err) {
                     logErrorPdf('Creating PDFs locally', err)


### PR DESCRIPTION
Newer branch of #137 
Change to pdf-gen:

 -   For every document, generate HTML -> MD5 hash
 -  Check if pdf exists at the S3 bucket specified by PDF_storage_URL and contains x-amz-meta-html-hash
 -   If exists and hash matches, end
 -  Else POST the HTML, name, MD5 hash and bucket name to the PDF Lambda function. The Lambda function will create the PDF and upload to the specified bucket:name.

To setup for new repo: change title in _config.yml. title will now be the folder name for pdfs from a single oepndoc repo and all the folders of pdfs will live the same Opendoc pdf bucket.

To generate offline: in _config.yml , specify offline: true