### PR TITLE
Control preloading with config.yml flag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ server_DEV: https://search-staging.opendoc.sg
 
 fast_build: true
 offline: false
-
+preload_pages: true
 
 subtitle: this is a subtitle
 order:

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -1,3 +1,5 @@
+---
+---
 (function () {
     var main = document.getElementsByTagName('main')[0]
     var tod = document.getElementsByClassName('table-of-directories')[0]
@@ -11,8 +13,10 @@
     var searchBoxElement = document.getElementById('search-box')
     var indexDiv = document.getElementById('index-div')
 
+    var preloadPages = '{{ site.preload_pages | default: true }}' === 'true'
+
     // If subfolder was accessed directory via url, load the subfolder's pages
-    if (documentTitle && documentTitle.innerText.trim()) {
+    if (documentTitle && documentTitle.innerText.trim() && preloadPages) {
         loadDocumentContent(documentTitle.innerText, 1)
     }
 


### PR DESCRIPTION
Allow users to decide whether they want to preload OpenDoc content
through the `preload_pages` flag. This is especially useful for
OpenDocs which have many pages on the root directory, like the
Rules of Court

TODO: Figure out how to preload sensibly, taking into account
constraints with mobile device connections or similar

TODO: Reduce page size, maybe by moving TOC to a separate file