### PR TITLE
siteIndex.json: rework how h1 is captured

### DIFF
--- a/assets/siteIndex.json
+++ b/assets/siteIndex.json
@@ -8,9 +8,9 @@
 {%- assign split_content = page.content | markdownify | split: '<h2' | splice: 1  -%}
         
 {%- comment -%}Deal with h1 section{%- endcomment -%}
-{%- assign page_header = split_content.first | split: '>' -%}
-{%- assign page_header = page_header[1] | split: '</h1' -%}
-{%- assign page_header = page_header[0] -%}
+{%- assign page_header = split_content.first | split: '</h1>' -%}
+{%- assign page_header = page_header.first | split: '">' -%}
+{%- assign page_header = page_header.last | strip_html | newline_to_br | strip_newlines | replace: '<br />', ' ' | replace: '\', '' | strip | smartify | normalize_whitespace -%}
 {%- assign header_section = '<h1' | append: split_content.first  | strip_html | newline_to_br | strip_newlines | replace: '<br />', ' ' | replace: '\', '' | strip | smartify | normalize_whitespace -%}
 {%- capture item -%}
 {


### PR DESCRIPTION
Originally, we capture h1 elements by splitting on `>`, then
looking up the second element (that is, element 1) of the resulting
array for the h1 content. This does not work well when there are
elements preceding the h1 tag (eg, style elements)

Make the h1 capture logic more resilient by splitting instead on
`</h1>`, taking the first element of the split array, then splitting
on `">`. This assumes that all header elements will have an attribute
set (usually id). The header text is then found at the last element of
this array